### PR TITLE
bugfix/213 - renamed underline slider tabs to underline tabs

### DIFF
--- a/demo/src/main/res/layout/fmt_tabs.xml
+++ b/demo/src/main/res/layout/fmt_tabs.xml
@@ -141,7 +141,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 app:admiralCellUnitType="leadingText"
-                app:admiralText="@string/tabs_underline_slider_title"
+                app:admiralText="@string/tabs_underline_title"
                 app:admiralTextStyle="body1" />
 
             <com.admiral.uikit.components.cell.unit.IconCellUnit

--- a/demo/src/main/res/layout/fmt_tabs_underline_slider.xml
+++ b/demo/src/main/res/layout/fmt_tabs_underline_slider.xml
@@ -14,7 +14,7 @@
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:admiralTitleText="@string/tabs_underline_slider_title" />
+            app:admiralTitleText="@string/tabs_underline_title" />
 
         <com.admiral.uikit.components.tabs.StandardTabs
             android:id="@+id/tabsState"

--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -75,7 +75,6 @@
     <string name="tabs_icon_title">Icon Tabs</string>
     <string name="tabs_informer_title">Informer Tabs</string>
     <string name="tabs_outline_title">Outline Slider Tabs</string>
-    <string name="tabs_underline_slider_title">Underline Slider Tabs</string>
     <string name="tabs_underline_center_title">Underline Center Tabs</string>
     <string name="tabs_informer_example_title">то получу в страховом случае</string>
     <string name="tabs_informer_example_summ">до 1 500 000 ₽</string>


### PR DESCRIPTION
Fix #213 
<img width="318" alt="image" src="https://github.com/admiral-team/admiralui-android/assets/90680880/b052423d-ff4a-4aab-992d-094d0742f17f">
