### PR TITLE
bugfix/580 - Returned Gravity.Center, fixed the ripple tag, fixed save/restore scroll state

### DIFF
--- a/admiral-uikit-compose/src/main/java/com/admiral/uikit/compose/tag/Tag.kt
+++ b/admiral-uikit-compose/src/main/java/com/admiral/uikit/compose/tag/Tag.kt
@@ -59,7 +59,7 @@ fun Tag(
             .clickable(
                 onClick = onClick,
                 enabled = isEnabled,
-                indication = rememberRipple(color = color.backgroundPressed),
+                indication = rememberRipple(),
                 interactionSource = remember { MutableInteractionSource() }
             ),
         verticalAlignment = Alignment.CenterVertically

--- a/admiral-uikit-notification/src/main/res/layout/admiral_notification_static.xml
+++ b/admiral-uikit-notification/src/main/res/layout/admiral_notification_static.xml
@@ -15,34 +15,37 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/module_x5"
-        tools:src="@drawable/admiral_ic_info_solid"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        tools:src="@drawable/admiral_ic_info_solid" />
 
-    <com.admiral.uikit.textview.TextView
-        android:id="@+id/admiralToastTextView"
+    <androidx.appcompat.widget.LinearLayoutCompat
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/module_x4"
         android:layout_marginEnd="@dimen/module_x4"
-        app:admiralTextStyle="body2"
+        android:orientation="vertical"
         app:layout_constraintEnd_toStartOf="@id/admiralCloseIcon"
         app:layout_constraintStart_toEndOf="@id/admiralIcon"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_goneMarginEnd="@dimen/module_x4"
-        tools:text="At breakpoint boundaries, mini units divide the screen into a fixed master grid." />
+        app:layout_constraintTop_toTopOf="@id/admiralIcon">
 
-    <com.admiral.uikit.links.Link
-        android:id="@+id/admiralLinkTextView"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/module_x2"
-        android:visibility="gone"
-        app:layout_constraintStart_toStartOf="@id/admiralToastTextView"
-        app:layout_constraintTop_toBottomOf="@id/admiralToastTextView"
-        app:layout_constraintEnd_toEndOf="@id/admiralToastTextView"
-        tools:admiralText="Link text"
-        tools:visibility="visible" />
+        <com.admiral.uikit.textview.TextView
+            android:id="@+id/admiralToastTextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:admiralTextStyle="body2"
+            app:layout_goneMarginEnd="@dimen/module_x4"
+            tools:text="At breakpoint boundaries, mini units divide the screen into a fixed master grid." />
+
+        <com.admiral.uikit.links.Link
+            android:id="@+id/admiralLinkTextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/module_x2"
+            android:visibility="gone"
+            tools:admiralText="Link text"
+            tools:visibility="visible" />
+    </androidx.appcompat.widget.LinearLayoutCompat>
 
     <ImageView
         android:id="@+id/admiralCloseIcon"

--- a/admiral-uikit/src/main/java/com/admiral/uikit/components/links/Link.kt
+++ b/admiral-uikit/src/main/java/com/admiral/uikit/components/links/Link.kt
@@ -63,7 +63,7 @@ class Link @JvmOverloads constructor(
 
     init {
         textStyle = ThemeManager.theme.typography.body2
-        gravity = Gravity.START
+        gravity = Gravity.CENTER
 
         parseAttrs(attrs, R.styleable.Link).use {
             text = it.getText(R.styleable.Link_admiralText)

--- a/admiral-uikit/src/main/res/layout/admiral_notification_static.xml
+++ b/admiral-uikit/src/main/res/layout/admiral_notification_static.xml
@@ -19,30 +19,33 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:src="@drawable/admiral_ic_info_solid" />
 
-    <com.admiral.uikit.components.text.TextView
-        android:id="@+id/admiralToastTextView"
+    <androidx.appcompat.widget.LinearLayoutCompat
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/module_x4"
         android:layout_marginEnd="@dimen/module_x4"
-        app:admiralTextStyle="body2"
+        android:orientation="vertical"
         app:layout_constraintEnd_toStartOf="@id/admiralCloseIcon"
         app:layout_constraintStart_toEndOf="@id/admiralIcon"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_goneMarginEnd="@dimen/module_x4"
-        tools:text="At breakpoint boundaries, mini units divide the screen into a fixed master grid." />
+        app:layout_constraintTop_toTopOf="@id/admiralIcon">
 
-    <com.admiral.uikit.components.links.Link
-        android:id="@+id/admiralLinkTextView"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/module_x2"
-        android:visibility="gone"
-        app:layout_constraintEnd_toEndOf="@id/admiralToastTextView"
-        app:layout_constraintStart_toStartOf="@id/admiralToastTextView"
-        app:layout_constraintTop_toBottomOf="@id/admiralToastTextView"
-        tools:admiralText="Link text"
-        tools:visibility="visible" />
+        <com.admiral.uikit.components.text.TextView
+            android:id="@+id/admiralToastTextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:admiralTextStyle="body2"
+            app:layout_goneMarginEnd="@dimen/module_x4"
+            tools:text="At breakpoint boundaries, mini units divide the screen into a fixed master grid." />
+
+        <com.admiral.uikit.components.links.Link
+            android:id="@+id/admiralLinkTextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/module_x2"
+            android:visibility="gone"
+            tools:admiralText="Link text"
+            tools:visibility="visible" />
+    </androidx.appcompat.widget.LinearLayoutCompat>
 
     <ImageView
         android:id="@+id/admiralCloseIcon"

--- a/admiral-uikit/src/main/res/layout/admiral_view_informer_big.xml
+++ b/admiral-uikit/src/main/res/layout/admiral_view_informer_big.xml
@@ -56,6 +56,6 @@
             android:layout_marginTop="16dp"
             android:ellipsize="end"
             app:admiralTextStyle="body2"
-            tools:text="Link" />
+            tools:admiralText="Link" />
     </LinearLayout>
 </merge>

--- a/demo/src/main/res/layout/fmt_home.xml
+++ b/demo/src/main/res/layout/fmt_home.xml
@@ -44,6 +44,7 @@
     </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.core.widget.NestedScrollView
+        android:id="@+id/nestedScrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:overScrollMode="never"


### PR DESCRIPTION
close #580 
- Вернул Gravity Center и поправил макет notification static, 
- Поправил цвет для ripple tag
- Поправил сохранение/восстановление состояния для стейта скролла главного экрана

[Демо](https://youtu.be/8Jpf5TDTRFw)
<img width="1024" alt="image" src="https://github.com/admiral-team/admiralui-android/assets/90680880/e5978ee1-bb80-4984-8835-649c66e29fbd">
<img width="1054" alt="image" src="https://github.com/admiral-team/admiralui-android/assets/90680880/3ccf27a5-f9f9-4c77-b2f7-69839de9622b">

