### PR TITLE
bugfix/592 fixed padding in slider tabs component

### DIFF
--- a/admiral-resources/src/main/res/values/palette.xml
+++ b/admiral-resources/src/main/res/values/palette.xml
@@ -5,6 +5,7 @@
 -->
 <resources>
     <color name="dark_backgroundAccent">#FF3A83F1</color>
+    <color name="dark_backgroundAccentTwo">#FF14315C</color>
     <color name="dark_backgroundAccentDark">#FF373B49</color>
     <color name="dark_backgroundAccentPressed">#FF326DC6</color>
     <color name="dark_backgroundAdditionalOne">#FF23262F</color>
@@ -90,6 +91,7 @@
     <color name="dark_textSuccessDefault">#FF89B79D</color>
     <color name="dark_textSuccessPressed">#FF338256</color>
     <color name="light_backgroundAccent">#FF3A83F1</color>
+    <color name="light_backgroundAccentTwo">#FF3A83F1</color>
     <color name="light_backgroundAccentDark">#FF0B1D37</color>
     <color name="light_backgroundAccentPressed">#FF316FCC</color>
     <color name="light_backgroundAdditionalOne">#FFF3F4F7</color>
@@ -175,6 +177,7 @@
     <color name="light_textSuccessDefault">#FF84D0A7</color>
     <color name="light_textSuccessPressed">#FF33985D</color>
     <color name="sMEDark_backgroundAccent">#FF189FE2</color>
+    <color name="sMEDark_backgroundAccentTwo">#FF14315C</color>
     <color name="sMEDark_backgroundAccentDark">#FF3F4553</color>
     <color name="sMEDark_backgroundAccentPressed">#FF137CB0</color>
     <color name="sMEDark_backgroundAdditionalOne">#FF303643</color>
@@ -260,6 +263,7 @@
     <color name="sMEDark_textSuccessDefault">#FF90D0BC</color>
     <color name="sMEDark_textSuccessPressed">#FF299B78</color>
     <color name="sMELight_backgroundAccent">#FF00AAFF</color>
+    <color name="sMELight_backgroundAccentTwo">#FF3A83F1</color>
     <color name="sMELight_backgroundAccentDark">#FFFFFFFF</color>
     <color name="sMELight_backgroundAccentPressed">#FF0099E5</color>
     <color name="sMELight_backgroundAdditionalOne">#FFF1F1F6</color>

--- a/admiral-uikit-compose/src/main/java/com/admiral/uikit/compose/badge/Badge.kt
+++ b/admiral-uikit-compose/src/main/java/com/admiral/uikit/compose/badge/Badge.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
-import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
@@ -31,24 +30,27 @@ import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.PlatformTextStyle
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextGeometricTransform
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.admiral.themes.compose.ThemeManagerCompose
-import com.admiral.themes.compose.Typography
 import com.admiral.uikit.compose.util.DIMEN_X1
 import com.admiral.uikit.compose.util.DIMEN_X2
 import com.admiral.uikit.compose.util.DIMEN_X4
+
+private const val BADGE_LAYOUT_ID = "BADGE_LAYOUT_ID"
+private const val ANCHOR_LAYOUT_ID = "ANCHOR_LAYOUT_ID"
+private const val MAX_LINES = 1
+private val BorderWidth = 2.dp
+private val SpaceBetweenBorder = 1.dp
+private val BadgeRadius = 5.dp
 
 @Composable
 fun BadgedBox(
     modifier: Modifier = Modifier,
     content: Int? = null,
     color: BadgeColor = AdmiralBadgeColor.normal(),
-    position: BadgePosition = AdmiralBadgePosition.standard(),
+    position: BadgePosition = AdmiralBadgePosition.default(),
     isEnable: Boolean = true,
     anchor: @Composable BoxScope.() -> Unit,
 ) {
@@ -95,7 +97,7 @@ fun BadgedBox(
         ) {
             // Use the width of the badge to infer whether it has any content (based on radius used
             // in [Badge]) and determine its horizontal offset.
-            val hasContent = badgePlaceable.width > (2 * BADGE_RADIUS.dp.roundToPx())
+            val hasContent = badgePlaceable.width > (2 * BadgeRadius.roundToPx())
             val badgeHorizontalOffset =
                 if (hasContent) position.badgeWithContentHorizontalOffset else position.badgeHorizontalOffset
             val badgeVerticalOffset =
@@ -118,7 +120,7 @@ private fun Badge(
     color: BadgeColor,
     isEnable: Boolean,
 ) {
-    val radius = if (content != null) BADGE_WITH_CONTENT_RADIUS.dp else BADGE_RADIUS.dp
+    val radius = if (content != null) DIMEN_X2 else BadgeRadius
     val shape = RoundedCornerShape(radius)
     val backgroundColor =
         if (isEnable) color.backgroundColorNormal else color.backgroundColorDisable
@@ -128,15 +130,15 @@ private fun Badge(
     Row(
         modifier = modifier
             .defaultMinSize(minWidth = radius * 2, minHeight = radius * 2)
-            .border(BORDER_WIDTH.dp, color = color.borderColor, shape = shape)
-            .padding(SPACE_BETWEEN_BORDER.dp)
+            .border(BorderWidth, color = color.borderColor, shape = shape)
+            .padding(SpaceBetweenBorder)
             .background(color = backgroundColor, shape = shape),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.Center
     ) {
         if (content != null) {
             Text(
-                modifier = Modifier.padding(horizontal = BADGE_WITH_CONTENT_HORIZONTAL_PADDING.dp - SPACE_BETWEEN_BORDER.dp),
+                modifier = Modifier.padding(horizontal = DIMEN_X1 - SpaceBetweenBorder),
                 text = content.toString(),
                 color = contentColor,
                 style = textStyle.copy(
@@ -150,15 +152,6 @@ private fun Badge(
         }
     }
 }
-
-private const val BADGE_LAYOUT_ID = "BADGE_LAYOUT_ID"
-private const val ANCHOR_LAYOUT_ID = "ANCHOR_LAYOUT_ID"
-private const val MAX_LINES = 1
-private const val BORDER_WIDTH = 2
-private const val SPACE_BETWEEN_BORDER = 1
-private const val BADGE_RADIUS = 5
-private const val BADGE_WITH_CONTENT_RADIUS = 8
-private const val BADGE_WITH_CONTENT_HORIZONTAL_PADDING = 4
 
 @Composable
 private fun IconWithBackground() {

--- a/admiral-uikit-compose/src/main/java/com/admiral/uikit/compose/badge/BadgePosition.kt
+++ b/admiral-uikit-compose/src/main/java/com/admiral/uikit/compose/badge/BadgePosition.kt
@@ -16,7 +16,7 @@ data class BadgePosition(
 
 object AdmiralBadgePosition {
     @Composable
-    fun standard(
+    fun default(
         badgeVerticalOffset: Dp = VERTICAL_OFFSET.dp,
         badgeVerticalWithContentOffset: Dp = VERTICAL_OFFSET_WITH_CONTENT.dp,
         badgeHorizontalOffset: Dp = HORIZONTAL_OFFSET.dp,

--- a/admiral-uikit-compose/src/main/java/com/admiral/uikit/compose/tabs/outline/OutlineSliderTab.kt
+++ b/admiral-uikit-compose/src/main/java/com/admiral/uikit/compose/tabs/outline/OutlineSliderTab.kt
@@ -3,13 +3,13 @@ package com.admiral.uikit.compose.tabs.outline
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -19,10 +19,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.toMutableStateList
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.admiral.themes.compose.ThemeManagerCompose
@@ -31,6 +33,12 @@ import com.admiral.uikit.compose.badge.AdmiralBadgePosition
 import com.admiral.uikit.compose.badge.BadgedBox
 import com.admiral.uikit.compose.util.DIMEN_X2
 import com.admiral.uikit.compose.util.DIMEN_X4
+
+private const val MAX_LINES = 1
+private val BorderActiveWidth = 2.dp
+private val BorderInactiveWidth = 1.dp
+private val BadgeVerticalOffset = (-9).dp
+private val BadgeHorizontalOffset = (-1).dp
 
 @Composable
 fun OutlineSliderTab(
@@ -55,22 +63,18 @@ fun OutlineSliderTab(
     }
     val textColor = if (isEnabled) color.textEnable else color.textDisable
     val textStyle = if (isSelected) activeTextStyle else inactiveTextStyle
-    val shape = RoundedCornerShape(TAB_CORNER_SHAPE_RADIUS.dp)
-    val borderWidth = if (isSelected) TAB_BORDER_ACTIVE_WIDTH else TAB_BORDER_INACTIVE_WIDTH
+    val shape = RoundedCornerShape(DIMEN_X2)
+    val borderWidth = if (isSelected) BorderActiveWidth else BorderInactiveWidth
 
     Tab(
         modifier = modifier
-            .height(TAB_HEIGHT.dp)
             .fillMaxWidth()
-            .border(borderWidth.dp, borderColor, shape)
-            .padding(SPACE_BETWEEN_BORDER.dp)
+            .border(borderWidth, borderColor, shape)
             .clip(shape),
         selected = isSelected,
         enabled = isEnabled,
-        onClick = {
-            onClick()
-        },
-        text = {
+        onClick = { onClick() },
+        content = {
             when {
                 isBadgeVisible -> OutlineSliderTabWithBadge(
                     text = tabText,
@@ -96,10 +100,14 @@ private fun OutlineSliderTab(
     textStyle: TextStyle,
 ) {
     Text(
+        modifier = Modifier
+            .padding(DIMEN_X2)
+            .wrapContentHeight(align = Alignment.CenterVertically),
         text = text,
         style = textStyle,
         color = textColor,
         maxLines = MAX_LINES,
+        textAlign = TextAlign.Center
     )
 }
 
@@ -110,25 +118,28 @@ private fun OutlineSliderTabWithBadge(
     textStyle: TextStyle,
     isBadgeEnabled: Boolean,
 ) {
-    Box(
-        modifier = Modifier.padding(
-            vertical = BADGE_TEXT_PADDING_VERTICAL.dp
-        )
+    Row(
+        modifier = Modifier
+            .padding(
+                end = DIMEN_X4,
+                start = DIMEN_X2,
+                top = DIMEN_X2,
+                bottom = DIMEN_X2
+            )
     ) {
         BadgedBox(
             color = AdmiralBadgeColor.normal(),
             isEnable = isBadgeEnabled,
             content = null,
-            position = AdmiralBadgePosition.standard(
-                badgeVerticalOffset = BADGE_VERTICAL_OFFSET.dp,
-                badgeHorizontalOffset = BADGE_HORIZONTAL_OFFSET.dp
+            position = AdmiralBadgePosition.default(
+                badgeVerticalOffset = BadgeVerticalOffset,
+                badgeHorizontalOffset = BadgeHorizontalOffset
             )
         ) {
             Text(
                 modifier = Modifier
-                    .padding(
-                        horizontal = BADGE_TEXT_PADDING_HORIZONTAL.dp,
-                    ),
+                    .wrapContentHeight(align = Alignment.CenterVertically)
+                    .padding(horizontal = DIMEN_X2),
                 text = text,
                 color = textColor,
                 style = textStyle,
@@ -137,17 +148,6 @@ private fun OutlineSliderTabWithBadge(
         }
     }
 }
-
-private const val TAB_CORNER_SHAPE_RADIUS = 8
-private const val TAB_BORDER_ACTIVE_WIDTH = 2
-private const val TAB_BORDER_INACTIVE_WIDTH = 1
-private const val SPACE_BETWEEN_BORDER = 1
-private const val TAB_HEIGHT = 32
-private const val MAX_LINES = 1
-private const val BADGE_VERTICAL_OFFSET = -9
-private const val BADGE_HORIZONTAL_OFFSET = -2
-private const val BADGE_TEXT_PADDING_HORIZONTAL = 8
-private const val BADGE_TEXT_PADDING_VERTICAL = 6
 
 @Immutable
 data class TabItem(

--- a/admiral-uikit-compose/src/main/java/com/admiral/uikit/compose/tabs/underline/UnderlineSliderTab.kt
+++ b/admiral-uikit-compose/src/main/java/com/admiral/uikit/compose/tabs/underline/UnderlineSliderTab.kt
@@ -1,5 +1,6 @@
 package com.admiral.uikit.compose.tabs.underline
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -120,7 +121,7 @@ private fun UnderlineSliderTabWithBadge(
             color = AdmiralBadgeColor.normal(),
             isEnable = isBadgeEnabled,
             content = null,
-            position = AdmiralBadgePosition.standard(
+            position = AdmiralBadgePosition.default(
                 badgeVerticalOffset = BADGE_VERTICAL_OFFSET.dp,
                 badgeHorizontalOffset = BADGE_HORIZONTAL_OFFSET.dp
             )
@@ -136,6 +137,7 @@ private fun UnderlineSliderTabWithBadge(
     }
 }
 
+@SuppressLint("ModifierFactoryUnreferencedReceiver")
 private fun Modifier.bottomBorder(strokeWidth: Dp, color: Color) = composed(
     factory = {
         val density = LocalDensity.current


### PR DESCRIPTION
Close #592 
- Поправил отступы для компонента outline slider tabs
- Провел небольшой рефакторинг
- Добавил токен цвета backgroundAccentTwo в генерируемый плагином фигмы палетку цветов
<img width="702" alt="image" src="https://github.com/admiral-team/admiralui-android/assets/90680880/2fd62670-be5a-465e-bf7d-a7d009f3aae7">

