### PR TITLE
[BUGFIX - 675] - fix InputNumber width without modifier

### DIFF
--- a/admiral-uikit-compose/src/main/java/com/admiral/uikit/compose/input/InputNumber.kt
+++ b/admiral-uikit-compose/src/main/java/com/admiral/uikit/compose/input/InputNumber.kt
@@ -48,14 +48,10 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.constraintlayout.compose.ConstraintLayout
-import androidx.constraintlayout.compose.Dimension
 import com.admiral.themes.compose.AdmiralTheme
 import com.admiral.uikit.compose.R
 import com.admiral.uikit.compose.util.DIMEN_X1
 import com.admiral.uikit.compose.util.DIMEN_X2
-import com.admiral.uikit.compose.util.DIMEN_X3
-import com.admiral.uikit.compose.util.DIMEN_X4
 import com.admiral.uikit.compose.util.DIMEN_X9
 import com.admiral.uikit.core.components.input.InputType
 import kotlinx.coroutines.CoroutineScope
@@ -131,192 +127,166 @@ fun InputNumber(
         decrementEnabled = autoIncrement.not() && currentValue != minValue
     }
 
-    ConstraintLayout(
+    Row(
         modifier = modifier,
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        val (
-            optionalTextId,
-            decrementIconId,
-            valueTextFieldId,
-            incrementIconId,
-        ) = createRefs()
-
         optionalText?.let { text ->
             Text(
-                modifier = Modifier
-                    .constrainAs(optionalTextId) {
-                        top.linkTo(parent.top)
-                        bottom.linkTo(parent.bottom)
-                        start.linkTo(anchor = parent.start, margin = DIMEN_X4)
-                        end.linkTo(anchor = decrementIconId.start, margin = DIMEN_X3)
-                        width = Dimension.fillToConstraints
-                    },
                 text = text,
                 style = AdmiralTheme.typography.body1,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 color = colors.getTextColor(isEnabled = isEnabled).value,
             )
+            Spacer(modifier = Modifier.width(DIMEN_X1))
         }
-
-        Box(
-            modifier = Modifier
-                .constrainAs(decrementIconId) {
-                    top.linkTo(parent.top)
-                    bottom.linkTo(parent.bottom)
-                    end.linkTo(anchor = valueTextFieldId.start, margin = textFieldMargin)
-                }
-                .background(
-                    color = colors.getBackgroundColor(isEnabled = isEnabled && decrementEnabled).value,
-                    shape = getIconShape(true, inputType),
-                )
-                .border(
-                    brush = SolidColor(colors.getIconBorderColor(isEnabled = isEnabled && decrementEnabled).value),
-                    shape = getIconShape(true, inputType),
-                    width = BorderWidth,
-                )
-                .clip(getIconShape(true, inputType))
-                .indication(
-                    interactionSource = decrementInteractionSource,
-                    indication = rememberRipple(color = colors.getRippleColor(isEnabled = isEnabled && decrementEnabled).value)
-                )
-                .pointerInput(isEnabled, decrementEnabled) {
-                    detectTapGestures(
-                        onPress = { offset: Offset ->
-                            val press = PressInteraction.Press(offset)
-                            decrementInteractionSource.emit(press)
-
-                            previousValue = currentValue
-                            currentValue--
-
-                            val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-                            val heldButtonJob = scope.launch {
-                                while (isEnabled && decrementEnabled) {
-                                    delay(DelayAutoChange)
-                                    autoDecrement = true
-                                    previousValue = currentValue
-                                    currentValue--
-                                }
-                            }
-                            tryAwaitRelease()
-                            decrementInteractionSource.emit(PressInteraction.Cancel(press))
-                            heldButtonJob.cancel()
-                            autoDecrement = false
-                        },
-                    )
-                }
-        ) {
-            Icon(
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
                 modifier = Modifier
-                    .padding(iconPadding),
-                painter = decrementIcon,
-                tint = colors.getIconTintColor(isEnabled = isEnabled && decrementEnabled).value,
-                contentDescription = null,
-            )
-        }
+                    .padding(start = DIMEN_X1)
+                    .background(
+                        color = colors.getBackgroundColor(isEnabled = isEnabled && decrementEnabled).value,
+                        shape = getIconShape(true, inputType),
+                    )
+                    .border(
+                        brush = SolidColor(colors.getIconBorderColor(isEnabled = isEnabled && decrementEnabled).value),
+                        shape = getIconShape(true, inputType),
+                        width = BorderWidth,
+                    )
+                    .clip(getIconShape(true, inputType))
+                    .indication(
+                        interactionSource = decrementInteractionSource,
+                        indication = rememberRipple(color = colors.getRippleColor(isEnabled = isEnabled && decrementEnabled).value)
+                    )
+                    .pointerInput(isEnabled, decrementEnabled) {
+                        detectTapGestures(
+                            onPress = { offset: Offset ->
+                                val press = PressInteraction.Press(offset)
+                                decrementInteractionSource.emit(press)
 
-        BasicTextField(
-            modifier = Modifier
-                .width(IntrinsicSize.Min)
-                .defaultMinSize(
-                    minWidth = textFieldMinWidth,
-                    minHeight = DIMEN_X9
-                )
-                .constrainAs(valueTextFieldId) {
-                    top.linkTo(parent.top)
-                    bottom.linkTo(parent.bottom)
-                    end.linkTo(anchor = incrementIconId.start, margin = textFieldMargin)
-                    width = Dimension.wrapContent
-                    height = Dimension.wrapContent
-                }
-                .background(color = colors.getTextFieldBackgroundColor(isEnabled = isEnabled).value),
-            value = valueWithSpaceState,
-            onValueChange = {},
-            enabled = isEnabled,
-            readOnly = inputType != InputType.TEXT_FIELD,
-            maxLines = 1,
-            cursorBrush = SolidColor(colors.getTextFieldCursorColor(isEnabled = isEnabled).value),
-            textStyle = AdmiralTheme.typography.body1.copy(
-                color = colors.getTextColor(isEnabled = isEnabled).value,
-                textAlign = TextAlign.Center,
-                platformStyle = PlatformTextStyle(
-                    includeFontPadding = false
-                )
-            ),
-            keyboardOptions = KeyboardOptions(
-                autoCorrect = false,
-                keyboardType = KeyboardType.Number
-            ),
-            decorationBox = @Composable { innerTextField ->
-                Row(
+                                previousValue = currentValue
+                                currentValue--
+
+                                val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+                                val heldButtonJob = scope.launch {
+                                    while (isEnabled && decrementEnabled) {
+                                        delay(DelayAutoChange)
+                                        autoDecrement = true
+                                        previousValue = currentValue
+                                        currentValue--
+                                    }
+                                }
+                                tryAwaitRelease()
+                                decrementInteractionSource.emit(PressInteraction.Cancel(press))
+                                heldButtonJob.cancel()
+                                autoDecrement = false
+                            },
+                        )
+                    }
+            ) {
+                Icon(
                     modifier = Modifier
-                        .padding(textFieldPadding),
-                    horizontalArrangement = Arrangement.Center,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Box(
-                        contentAlignment = Alignment.Center,
+                        .padding(iconPadding),
+                    painter = decrementIcon,
+                    tint = colors.getIconTintColor(isEnabled = isEnabled && decrementEnabled).value,
+                    contentDescription = null,
+                )
+            }
+
+            BasicTextField(
+                modifier = Modifier
+                    .width(IntrinsicSize.Min)
+                    .defaultMinSize(
+                        minWidth = textFieldMinWidth,
+                        minHeight = DIMEN_X9
+                    )
+                    .padding(horizontal = if (inputType == InputType.TEXT_FIELD) TextFieldMargin else DIMEN_X1)
+                    .background(color = colors.getTextFieldBackgroundColor(isEnabled = isEnabled).value),
+                value = valueWithSpaceState,
+                onValueChange = {},
+                enabled = isEnabled,
+                readOnly = inputType != InputType.TEXT_FIELD,
+                maxLines = 1,
+                cursorBrush = SolidColor(colors.getTextFieldCursorColor(isEnabled = isEnabled).value),
+                textStyle = AdmiralTheme.typography.body1.copy(
+                    color = colors.getTextColor(isEnabled = isEnabled).value,
+                    textAlign = TextAlign.Center,
+                    platformStyle = PlatformTextStyle(
+                        includeFontPadding = false
+                    )
+                ),
+                keyboardOptions = KeyboardOptions(
+                    autoCorrect = false,
+                    keyboardType = KeyboardType.Number
+                ),
+                decorationBox = @Composable { innerTextField ->
+                    Row(
+                        modifier = Modifier
+                            .padding(textFieldPadding),
+                        horizontalArrangement = Arrangement.Center,
+                        verticalAlignment = Alignment.CenterVertically
                     ) {
-                        innerTextField()
+                        Box(
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            innerTextField()
+                        }
                     }
                 }
-            }
-        )
-
-        Box(
-            modifier = Modifier
-                .constrainAs(incrementIconId) {
-                    top.linkTo(parent.top)
-                    bottom.linkTo(parent.bottom)
-                    end.linkTo(anchor = parent.end, margin = DIMEN_X4)
-                }
-                .background(
-                    color = colors.getBackgroundColor(isEnabled = isEnabled && incrementEnabled).value,
-                    shape = getIconShape(false, inputType)
-                )
-                .border(
-                    brush = SolidColor(colors.getIconBorderColor(isEnabled = isEnabled && incrementEnabled).value),
-                    shape = getIconShape(false, inputType),
-                    width = BorderWidth,
-                )
-                .clip(getIconShape(false, inputType))
-                .indication(
-                    interactionSource = incrementInteractionSource,
-                    indication = rememberRipple(color = colors.getRippleColor(isEnabled = isEnabled && incrementEnabled).value)
-                )
-                .pointerInput(isEnabled, incrementEnabled) {
-                    detectTapGestures(
-                        onPress = { offset: Offset ->
-                            val press = PressInteraction.Press(offset)
-                            incrementInteractionSource.emit(press)
-
-                            previousValue = currentValue
-                            currentValue++
-
-                            val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-                            val heldButtonJob = scope.launch {
-                                while (isEnabled && incrementEnabled) {
-                                    delay(DelayAutoChange)
-                                    autoIncrement = true
-                                    previousValue = currentValue
-                                    currentValue++
-                                }
-                            }
-                            tryAwaitRelease()
-                            incrementInteractionSource.emit(PressInteraction.Cancel(press))
-                            heldButtonJob.cancel()
-                            autoIncrement = false
-                        },
-                    )
-                }
-        ) {
-            Icon(
-                modifier = Modifier
-                    .padding(iconPadding),
-                painter = incrementIcon,
-                tint = colors.getIconTintColor(isEnabled = isEnabled && incrementEnabled).value,
-                contentDescription = null
             )
+
+            Box(
+                modifier = Modifier
+                    .background(
+                        color = colors.getBackgroundColor(isEnabled = isEnabled && incrementEnabled).value,
+                        shape = getIconShape(false, inputType)
+                    )
+                    .border(
+                        brush = SolidColor(colors.getIconBorderColor(isEnabled = isEnabled && incrementEnabled).value),
+                        shape = getIconShape(false, inputType),
+                        width = BorderWidth,
+                    )
+                    .clip(getIconShape(false, inputType))
+                    .indication(
+                        interactionSource = incrementInteractionSource,
+                        indication = rememberRipple(color = colors.getRippleColor(isEnabled = isEnabled && incrementEnabled).value)
+                    )
+                    .pointerInput(isEnabled, incrementEnabled) {
+                        detectTapGestures(
+                            onPress = { offset: Offset ->
+                                val press = PressInteraction.Press(offset)
+                                incrementInteractionSource.emit(press)
+
+                                previousValue = currentValue
+                                currentValue++
+
+                                val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+                                val heldButtonJob = scope.launch {
+                                    while (isEnabled && incrementEnabled) {
+                                        delay(DelayAutoChange)
+                                        autoIncrement = true
+                                        previousValue = currentValue
+                                        currentValue++
+                                    }
+                                }
+                                tryAwaitRelease()
+                                incrementInteractionSource.emit(PressInteraction.Cancel(press))
+                                heldButtonJob.cancel()
+                                autoIncrement = false
+                            },
+                        )
+                    }
+            ) {
+                Icon(
+                    modifier = Modifier
+                        .padding(iconPadding),
+                    painter = incrementIcon,
+                    tint = colors.getIconTintColor(isEnabled = isEnabled && incrementEnabled).value,
+                    contentDescription = null
+                )
+            }
         }
     }
 }

--- a/demo/src/main/java/com/admiral/demo/compose/home/textfield/NumberDefaultTextFieldScreen.kt
+++ b/demo/src/main/java/com/admiral/demo/compose/home/textfield/NumberDefaultTextFieldScreen.kt
@@ -48,12 +48,13 @@ fun NumberDefaultTextFieldsScreen(onBackClick: () -> Unit = {}) {
     ) { padding ->
         Column(
             modifier = Modifier
+                .padding(horizontal = DIMEN_X4)
                 .padding(padding)
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
         ) {
             StandardTab(
-                modifier = Modifier.padding(horizontal = DIMEN_X4),
+                modifier = Modifier,
                 items = mutableListOf(
                     stringResource(id = R.string.tabs_default),
                     stringResource(id = R.string.tabs_disabled),
@@ -66,7 +67,7 @@ fun NumberDefaultTextFieldsScreen(onBackClick: () -> Unit = {}) {
 
             Spacer(modifier = Modifier.size(DIMEN_X13))
             Text(
-                modifier = Modifier.padding(horizontal = DIMEN_X4),
+                modifier = Modifier,
                 text = stringResource(id = R.string.text_fields_five_symbols),
                 style = ThemeManagerCompose.typography.body1,
                 color = AdmiralTheme.colors.textSecondary
@@ -84,7 +85,7 @@ fun NumberDefaultTextFieldsScreen(onBackClick: () -> Unit = {}) {
 
             Spacer(modifier = Modifier.size(DIMEN_X9))
             Text(
-                modifier = Modifier.padding(horizontal = DIMEN_X4),
+                modifier = Modifier,
                 text = stringResource(id = R.string.text_fields_six_symbols),
                 style = ThemeManagerCompose.typography.body1,
                 color = AdmiralTheme.colors.textSecondary
@@ -102,7 +103,7 @@ fun NumberDefaultTextFieldsScreen(onBackClick: () -> Unit = {}) {
 
             Spacer(modifier = Modifier.size(DIMEN_X9))
             Text(
-                modifier = Modifier.padding(horizontal = DIMEN_X4),
+                modifier = Modifier,
                 text = stringResource(id = R.string.text_fields_eight_symbols),
                 style = ThemeManagerCompose.typography.body1,
                 color = AdmiralTheme.colors.textSecondary
@@ -120,7 +121,7 @@ fun NumberDefaultTextFieldsScreen(onBackClick: () -> Unit = {}) {
 
             Spacer(modifier = Modifier.size(DIMEN_X9))
             Text(
-                modifier = Modifier.padding(horizontal = DIMEN_X4),
+                modifier = Modifier,
                 text = stringResource(id = R.string.text_fields_ten_symbols),
                 style = ThemeManagerCompose.typography.body1,
                 color = AdmiralTheme.colors.textSecondary
@@ -138,7 +139,7 @@ fun NumberDefaultTextFieldsScreen(onBackClick: () -> Unit = {}) {
 
             Spacer(modifier = Modifier.size(DIMEN_X9))
             Text(
-                modifier = Modifier.padding(horizontal = DIMEN_X4),
+                modifier = Modifier,
                 text = stringResource(id = R.string.text_fields_unlimeted_symbols),
                 style = ThemeManagerCompose.typography.body1,
                 color = AdmiralTheme.colors.textSecondary

--- a/demo/src/main/java/com/admiral/demo/compose/home/textfield/NumberSecondaryTextFieldScreen.kt
+++ b/demo/src/main/java/com/admiral/demo/compose/home/textfield/NumberSecondaryTextFieldScreen.kt
@@ -48,12 +48,12 @@ fun NumberSecondaryTextFieldsScreen(onBackClick: () -> Unit = {}) {
     ) { padding ->
         Column(
             modifier = Modifier
+                .padding(DIMEN_X4)
                 .padding(padding)
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
         ) {
             StandardTab(
-                modifier = Modifier.padding(horizontal = DIMEN_X4),
                 items = mutableListOf(
                     stringResource(id = R.string.tabs_default),
                     stringResource(id = R.string.tabs_disabled),
@@ -66,7 +66,6 @@ fun NumberSecondaryTextFieldsScreen(onBackClick: () -> Unit = {}) {
 
             Spacer(modifier = Modifier.size(DIMEN_X13))
             Text(
-                modifier = Modifier.padding(horizontal = DIMEN_X4),
                 text = stringResource(id = R.string.text_fields_five_symbols),
                 style = ThemeManagerCompose.typography.body1,
                 color = AdmiralTheme.colors.textSecondary
@@ -84,7 +83,6 @@ fun NumberSecondaryTextFieldsScreen(onBackClick: () -> Unit = {}) {
 
             Spacer(modifier = Modifier.size(DIMEN_X9))
             Text(
-                modifier = Modifier.padding(horizontal = DIMEN_X4),
                 text = stringResource(id = R.string.text_fields_six_symbols),
                 style = ThemeManagerCompose.typography.body1,
                 color = AdmiralTheme.colors.textSecondary
@@ -102,7 +100,6 @@ fun NumberSecondaryTextFieldsScreen(onBackClick: () -> Unit = {}) {
 
             Spacer(modifier = Modifier.size(DIMEN_X9))
             Text(
-                modifier = Modifier.padding(horizontal = DIMEN_X4),
                 text = stringResource(id = R.string.text_fields_eight_symbols),
                 style = ThemeManagerCompose.typography.body1,
                 color = AdmiralTheme.colors.textSecondary
@@ -120,7 +117,6 @@ fun NumberSecondaryTextFieldsScreen(onBackClick: () -> Unit = {}) {
 
             Spacer(modifier = Modifier.size(DIMEN_X9))
             Text(
-                modifier = Modifier.padding(horizontal = DIMEN_X4),
                 text = stringResource(id = R.string.text_fields_ten_symbols),
                 style = ThemeManagerCompose.typography.body1,
                 color = AdmiralTheme.colors.textSecondary
@@ -138,7 +134,6 @@ fun NumberSecondaryTextFieldsScreen(onBackClick: () -> Unit = {}) {
 
             Spacer(modifier = Modifier.size(DIMEN_X9))
             Text(
-                modifier = Modifier.padding(horizontal = DIMEN_X4),
                 text = stringResource(id = R.string.text_fields_unlimeted_symbols),
                 style = ThemeManagerCompose.typography.body1,
                 color = AdmiralTheme.colors.textSecondary


### PR DESCRIPTION
если мы устанавливаем modifier.fillMaxWidth - контент расширяется по ширине родителя
<img width="409" alt="Screenshot 2024-05-10 at 00 40 00" src="https://github.com/admiral-team/admiralui-android/assets/20974161/66d45888-9696-4d37-9ed2-ce6b1485ab02">

если мы не устанавливаем modifier - контент расширяется по своему контенту
<img width="409" alt="Screenshot 2024-05-10 at 00 40 37" src="https://github.com/admiral-team/admiralui-android/assets/20974161/d332f047-5c35-498f-84b5-86fe90706ed5">
