### PR TITLE
feat/696 added text component to compose

### DIFF
--- a/admiral-uikit-compose/src/main/java/com/admiral/uikit/compose/text/Text.kt
+++ b/admiral-uikit-compose/src/main/java/com/admiral/uikit/compose/text/Text.kt
@@ -1,0 +1,73 @@
+package com.admiral.uikit.compose.text
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.TextUnit
+import com.admiral.themes.compose.AdmiralTheme
+
+@Suppress("LongParameterList")
+@Composable
+fun Text(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: TextColor = AdmiralTextColor.primary(),
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    isEnabled: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    minLines: Int = 1,
+    onTextLayout: ((TextLayoutResult) -> Unit)? = null,
+    style: TextStyle = AdmiralTheme.typography.subhead1,
+) {
+    androidx.compose.material.Text(
+        text = text,
+        modifier = modifier,
+        color = color.getTextNormalColor(enabled = isEnabled).value,
+        fontSize = fontSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        onTextLayout = onTextLayout,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        minLines = minLines,
+        style = style,
+    )
+}
+
+@Preview
+@Composable
+private fun TextViewPreview() {
+    AdmiralTheme {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = AdmiralTheme.colors.backgroundBasic
+        ) {
+            Text(text = "Admiral Design System")
+        }
+    }
+}

--- a/admiral-uikit-compose/src/main/java/com/admiral/uikit/compose/text/TextColor.kt
+++ b/admiral-uikit-compose/src/main/java/com/admiral/uikit/compose/text/TextColor.kt
@@ -2,6 +2,8 @@ package com.admiral.uikit.compose.text
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.graphics.Color
 import com.admiral.themes.compose.AdmiralTheme
 import com.admiral.themes.compose.withAlpha
@@ -10,7 +12,11 @@ import com.admiral.themes.compose.withAlpha
 data class TextColor(
     val textColorNormal: Color,
     val textColorDisabled: Color,
-)
+) {
+    @Composable
+    fun getTextNormalColor(enabled: Boolean): State<Color> =
+        rememberUpdatedState(if (enabled) textColorNormal else textColorDisabled)
+}
 
 object AdmiralTextColor {
     @Composable


### PR DESCRIPTION
Close #696 
Добавил компонент Text в компоуз с обработкой нашей типографики и цвета
<img width="435" alt="image" src="https://github.com/admiral-team/admiralui-android/assets/90680880/5fe7cb25-262b-4a9e-940c-7efc3a5e5384">
